### PR TITLE
Make logging asynchronous and improve log panel

### DIFF
--- a/ProductManager/MainViewModel.cs
+++ b/ProductManager/MainViewModel.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Input;
 
 namespace ProductManager
@@ -26,9 +27,9 @@ namespace ProductManager
         public MainViewModel()
         {
             BrowseFolderCommand = new RelayCommand(_ => BrowseAndLoad());
-            RefreshAllCommand = new RelayCommand(_ => RefreshAll());
-            UpdateAllCommand = new RelayCommand(_ => UpdateAll());
-            CheckoutAllCommand = new RelayCommand(_ => CheckoutAll());
+            RefreshAllCommand = new RelayCommand(async _ => await RefreshAllAsync());
+            UpdateAllCommand = new RelayCommand(async _ => await UpdateAllAsync());
+            CheckoutAllCommand = new RelayCommand(async _ => await CheckoutAllAsync());
             SelectAllCommand = new RelayCommand(_ => SelectAll());
             UnselectAllCommand = new RelayCommand(_ => UnselectAll());
         }
@@ -53,31 +54,31 @@ namespace ProductManager
             }
         }
 
-        private void RefreshAll()
+        private async Task RefreshAllAsync()
         {
             foreach (var sm in Submodules.Where(x => x.IsSelected))
             {
-                sm.RefreshCommand.Execute(null);
+                await sm.RefreshAsync();
                 AppendLog($"Refreshed {sm.Name}");
             }
         }
 
 
-        private void UpdateAll()
+        private async Task UpdateAllAsync()
         {
             foreach (var sm in Submodules.Where(x => x.IsSelected))
             {
-                sm.PullCommand.Execute(null);
+                await sm.PullAsync();
                 AppendLog($"Updated {sm.Name}");
             }
         }
 
 
-        private void CheckoutAll()
+        private async Task CheckoutAllAsync()
         {
             foreach (var sm in Submodules.Where(x => x.IsSelected))
             {
-                sm.CheckoutCommand.Execute(null);
+                await sm.CheckoutAsync();
                 AppendLog($"Checked out {sm.Name} to {sm.SelectedBranch}");
             }
         }
@@ -172,8 +173,11 @@ namespace ProductManager
 
         public void AppendLog(string message)
         {
-            Log.Add($"[{DateTime.Now:HH:mm:ss}] {message}");
-            OnPropertyChanged(nameof(Log));
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                Log.Add($"[{DateTime.Now:HH:mm:ss}] {message}");
+                OnPropertyChanged(nameof(Log));
+            });
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/ProductManager/MainWindow.xaml
+++ b/ProductManager/MainWindow.xaml
@@ -12,8 +12,13 @@
     <Window.Resources>
         <local:LogJoinConverter x:Key="LogJoinConverter" />
     </Window.Resources>
-    <DockPanel>
-        <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="5">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="5">
             <Button Content="Open Folder" Command="{Binding BrowseFolderCommand}" Margin="0,0,6,0" />
             <Button Content="Refresh All" Command="{Binding RefreshAllCommand}" Margin="0,0,6,0" />
             <Button Content="Update All" Command="{Binding UpdateAllCommand}" Margin="0,0,6,0" />
@@ -21,20 +26,19 @@
             <Button Content="Select All" Command="{Binding SelectAllCommand}" Margin="0,0,6,0"/>
             <Button Content="Unselect All" Command="{Binding UnselectAllCommand}" />
         </StackPanel>
-        <DataGrid DockPanel.Dock="Top"
+        <DataGrid Grid.Row="1"
             ItemsSource="{Binding Submodules}"
             AutoGenerateColumns="False"
-            Margin="5"
-            Height="300">
+            Margin="5">
             <DataGrid.Columns>
                 <DataGridCheckBoxColumn Header="Select" Binding="{Binding IsSelected, Mode=TwoWay}" Width="Auto" />
                 <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*" />
                 <DataGridTemplateColumn Header="Branch" Width="2*">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <ComboBox ItemsSource="{Binding Branches}" 
-                                SelectedItem="{Binding SelectedBranch, 
-                                Mode=TwoWay, 
+                            <ComboBox ItemsSource="{Binding Branches}"
+                                SelectedItem="{Binding SelectedBranch,
+                                Mode=TwoWay,
                                 UpdateSourceTrigger=PropertyChanged}" />
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
@@ -53,13 +57,13 @@
             </DataGrid.Columns>
         </DataGrid>
         <!-- Log panel -->
-        <TextBox DockPanel.Dock="Bottom"
+        <TextBox Grid.Row="2"
             Text="{Binding Log, Converter={StaticResource LogJoinConverter}, Mode=OneWay}"
             AcceptsReturn="True"
             IsReadOnly="True"
             VerticalScrollBarVisibility="Auto"
             HorizontalScrollBarVisibility="Auto"
-            Height="200"
-            Margin="5"/>
-    </DockPanel>
+            Margin="5"
+            TextChanged="LogTextBox_TextChanged"/>
+    </Grid>
 </Window>

--- a/ProductManager/MainWindow.xaml.cs
+++ b/ProductManager/MainWindow.xaml.cs
@@ -21,5 +21,10 @@ namespace ProductManager
         {
             InitializeComponent();
         }
+
+        private void LogTextBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            (sender as TextBox)?.ScrollToEnd();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- perform submodule operations and logging on background threads
- resizeable log panel that autoscrolls to newest entry

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c32b9440ac8323b3adb615ac3a3360