### PR TITLE
Handle remote branch checkout properly

### DIFF
--- a/ProductManager/GitSubmodule.cs
+++ b/ProductManager/GitSubmodule.cs
@@ -25,8 +25,20 @@ namespace ProductManager
 
         public void CheckoutBranch(string branchName)
         {
-            RunGit($"checkout {branchName}", Path);
-            CurrentBranch = branchName;
+            if (string.IsNullOrWhiteSpace(branchName))
+                return;
+
+            if (branchName.Contains('/'))
+            {
+                var local = branchName.Substring(branchName.IndexOf('/') + 1);
+                RunGit($"checkout --track -B {local} {branchName}", Path);
+                CurrentBranch = local;
+            }
+            else
+            {
+                RunGit($"checkout {branchName}", Path);
+                CurrentBranch = branchName;
+            }
         }
 
         public void PullLatest()


### PR DESCRIPTION
## Summary
- create a local tracking branch when checking out a remote branch
- skip checkout when branch name is empty

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c331d93ba48323b4ab6de9834102c3