### PR TITLE
feat: manage popular branches across submodules

### DIFF
--- a/ProductManager/MainWindow.xaml
+++ b/ProductManager/MainWindow.xaml
@@ -18,13 +18,27 @@
             <RowDefinition Height="*" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="5">
-            <Button Content="Open Folder" Command="{Binding BrowseFolderCommand}" Margin="0,0,6,0" />
-            <Button Content="Refresh All" Command="{Binding RefreshAllCommand}" Margin="0,0,6,0" />
-            <Button Content="Update All" Command="{Binding UpdateAllCommand}" Margin="0,0,6,0" />
-            <Button Content="Checkout All" Command="{Binding CheckoutAllCommand}" Margin="0,0,6,0"/>
-            <Button Content="Select All" Command="{Binding SelectAllCommand}" Margin="0,0,6,0"/>
-            <Button Content="Unselect All" Command="{Binding UnselectAllCommand}" />
+        <StackPanel Grid.Row="0" Margin="5">
+            <StackPanel Orientation="Horizontal">
+                <Button Content="Open Folder" Command="{Binding BrowseFolderCommand}" Margin="0,0,6,0" />
+                <Button Content="Refresh All" Command="{Binding RefreshAllCommand}" Margin="0,0,6,0" />
+                <Button Content="Update All" Command="{Binding UpdateAllCommand}" Margin="0,0,6,0" />
+                <Button Content="Checkout All" Command="{Binding CheckoutAllCommand}" Margin="0,0,6,0"/>
+                <Button Content="Select All" Command="{Binding SelectAllCommand}" Margin="0,0,6,0"/>
+                <Button Content="Unselect All" Command="{Binding UnselectAllCommand}" />
+            </StackPanel>
+            <ItemsControl ItemsSource="{Binding PopularBranches}" Margin="0,5,0,0">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Button Content="{Binding}" Command="{Binding DataContext.SelectPopularBranchCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding}" Margin="0,0,6,0" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
         </StackPanel>
         <DataGrid Grid.Row="1"
             ItemsSource="{Binding Submodules}"
@@ -49,7 +63,8 @@
                             <StackPanel Orientation="Horizontal">
                                 <Button Content="Refresh" Command="{Binding RefreshCommand}" Margin="0,0,6,0" />
                                 <Button Content="Update" Command="{Binding PullCommand}" Margin="0,0,6,0" />
-                                <Button Content="Checkout" Command="{Binding CheckoutCommand}" />
+                                <Button Content="Checkout" Command="{Binding CheckoutCommand}" Margin="0,0,6,0" />
+                                <Button Content="Add" Command="{Binding AddPopularBranchCommand}" />
                             </StackPanel>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>

--- a/ProductManager/MainWindow.xaml.cs
+++ b/ProductManager/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+using System;
+using System.Collections.ObjectModel;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;
@@ -25,6 +26,13 @@ namespace ProductManager
         private void LogTextBox_TextChanged(object sender, TextChangedEventArgs e)
         {
             (sender as TextBox)?.ScrollToEnd();
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            if (DataContext is MainViewModel vm)
+                vm.SavePopularBranches();
+            base.OnClosed(e);
         }
     }
 }

--- a/ProductManager/SubmoduleViewModel.cs
+++ b/ProductManager/SubmoduleViewModel.cs
@@ -49,18 +49,18 @@ namespace ProductManager
         public ICommand RefreshCommand { get; }
         public ICommand PullCommand { get; }
         public ICommand CheckoutCommand { get; }
+        public ICommand AddPopularBranchCommand { get; }
 
-        public SubmoduleViewModel(GitSubmodule model)
+        public SubmoduleViewModel(GitSubmodule model, Action<string> addPopularBranch)
         {
             _model = model;
             Branches = new ObservableCollection<string>(_model.Branches ?? new string[0]);
             _selectedBranch = _model.CurrentBranch;
 
             RefreshCommand = new RelayCommand(_ => _ = RefreshAsync());
-
             PullCommand = new RelayCommand(_ => _ = PullAsync());
-
             CheckoutCommand = new RelayCommand(_ => _ = CheckoutAsync());
+            AddPopularBranchCommand = new RelayCommand(_ => addPopularBranch?.Invoke(SelectedBranch));
         }
 
         public Task RefreshAsync()


### PR DESCRIPTION
## Summary
- allow saving and loading popular branches per repository
- add UI buttons to apply popular branches and add current branch to list
- persist popular branch list on app close

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c34756cc188323bb8e86caf2511438